### PR TITLE
bugfixes_with_arrayqueue_and_arraystack

### DIFF
--- a/python/ods/arrayqueue.py
+++ b/python/ods/arrayqueue.py
@@ -26,6 +26,9 @@ class ArrayQueue(BaseList):
         self.n += 1
         return True
 
+    def append(self, x):
+        self.add(x)
+
     def remove(self):
         if self.n == 0: raise IndexError()
         x = self.a[self.j]

--- a/python/ods/arraystack.py
+++ b/python/ods/arraystack.py
@@ -5,7 +5,7 @@ amortizado de O(1 + n-i).
 
 Armazena a lista em uma matriz, a, de modo que o i-ésimo item da lista
 seja armazenado em a[(j+i)%len(a)].
-
+"""
 from base import BaseList
 
 class ArrayStack(BaseList):


### PR DESCRIPTION
arrayqueue.py: o método append() da BaseList utilza o método add() com dois argumentos enquanto o add() criado dentro de ArrayQueue possui apenas um parametro (além do self).

arraystack.py: simplesmente faltou fechar o texto com """